### PR TITLE
Add write duration sensor for Gicisky BLE integration

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "gicisky",
+  "name": "Gicisky",
   "render_readme": true,
   "homeassistant": "2025.1.0"
 }


### PR DESCRIPTION
Introduces a duration sensor entity to track and expose the time taken for BLE write operations in the Gicisky integration. Adds a DataUpdateCoordinator and background task to update the duration in real time, and registers the new sensor entity. Also updates the integration name in hacs.json.