### PR TITLE
Add new device entry for EPD 2.9 BW

### DIFF
--- a/custom_components/gicisky/gicisky_ble/devices.py
+++ b/custom_components/gicisky/gicisky_ble/devices.py
@@ -108,6 +108,15 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         rotation=270,
         mirror_x=True
     ),
+    0x0028: DeviceEntry(
+        name="EPD 29",
+        model="EPD 2.9\" BW",
+        width=296,
+        height=128,
+        rotation=90,
+        red=False,
+        max_voltage=3.0
+    ),
     0x0033: DeviceEntry(
         name="EPD 29",
         model="EPD 2.9\" BWR",


### PR DESCRIPTION
I had to add this entry to be able to control my Gicisky 2.9'' BW EPD. Seems to work fine. Would be nice to have this added so I can keep updating the integration in the future and not be stuck on my custom version.

no idea what the change on line 179 is or how it happened - seems to be the same. I was using the web editor of github. might be down to microsoft vibecoding their website.