### PR TITLE
Set entity categories for Alias and diagnostic sensors

### DIFF
--- a/custom_components/gicisky/sensor.py
+++ b/custom_components/gicisky/sensor.py
@@ -346,6 +346,7 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # Volume (L)
     (
@@ -495,6 +496,7 @@ class GiciskyDurationSensorEntity(
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_native_unit_of_measurement = UnitOfTime.SECONDS
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,
@@ -551,6 +553,7 @@ class GiciskyFailureCountSensorEntity(
 
     _attr_state_class = SensorStateClass.TOTAL
     _attr_icon = "mdi:alert-circle"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,
@@ -595,6 +598,7 @@ class GiciskyLastFailureTimeSensorEntity(
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:clock-alert"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/custom_components/gicisky/text.py
+++ b/custom_components/gicisky/text.py
@@ -3,7 +3,7 @@ from homeassistant.components.text import TextEntity, RestoreText
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import DeviceInfo, CONNECTION_BLUETOOTH
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import EntityCategory, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.restore_state import RestoreEntity
 from propcache.api import cached_property
@@ -30,6 +30,7 @@ class GiciskyTextEntity(RestoreText):
         self._attr_native_max = 32  # Reasonable max length for text fields
         self._attr_native_min = 0
         self._attr_mode = "text"
+        self._attr_entity_category = EntityCategory.CONFIG
         self._attr_native_value = f"{self._identifier}"
 
     @property


### PR DESCRIPTION
## Summary
- Set **Alias** text entity category to `configuration`
- Set **Voltage**, **Write Duration**, **Failure Count**, and **Last Failure Time** sensor categories to `diagnostic`

Just doing some decluttering of the device categories to match recommended HA category groups.