### PR TITLE
Introduce WriteLock support to prevent physical screen updates

### DIFF
--- a/custom_components/gicisky/__init__.py
+++ b/custom_components/gicisky/__init__.py
@@ -38,6 +38,7 @@ from .const import (
     DEFAULT_RETRY_COUNT,
     DEFAULT_WRITE_DELAY_MS,
     DEFAULT_PREVENT_DUPLICATE_SEND,
+    WRITE_LOCK,
 )
 from .coordinator import GiciskyPassiveBluetoothProcessorCoordinator
 from .types import GiciskyConfigEntry
@@ -47,7 +48,8 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.CAMERA,
     Platform.IMAGE,
-    Platform.TEXT
+    Platform.TEXT,
+    Platform.SWITCH,
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -211,6 +213,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
 
                 # If dry_run is True, skip sending to the actual device
                 if dry_run:
+                    continue
+
+                # If write lock is on, update image coordinator but skip BLE
+                if hass.data[DOMAIN][entry_id].get(WRITE_LOCK, False):
+                    _LOGGER.info(f"Write lock active for {address} — skipping BLE write")
+                    image_coordinator.async_set_updated_data(current_image_data)
                     continue
 
                 # Start duration tracking

--- a/custom_components/gicisky/const.py
+++ b/custom_components/gicisky/const.py
@@ -15,4 +15,7 @@ DEFAULT_RETRY_COUNT = 3
 DEFAULT_WRITE_DELAY_MS = 0
 DEFAULT_PREVENT_DUPLICATE_SEND = False
 
+# Runtime state keys
+WRITE_LOCK = "write_lock"
+
 

--- a/custom_components/gicisky/switch.py
+++ b/custom_components/gicisky/switch.py
@@ -1,0 +1,103 @@
+"""Support for Gicisky write lock switch."""
+
+import logging
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from propcache.api import cached_property
+
+from .const import DOMAIN, WRITE_LOCK
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Gicisky write lock switch."""
+    async_add_entities([GiciskyWriteLockSwitch(hass, entry)])
+
+
+class GiciskyWriteLockSwitch(RestoreEntity, SwitchEntity):
+    """Switch that locks physical writes (virtual updates still apply)."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:lock"
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        address = hass.data[DOMAIN][entry.entry_id]["address"]
+        self._address = address
+        self._identifier = address.replace(":", "")[-8:]
+        self._attr_name = f"Gicisky {self._identifier} Write Lock"
+        self._attr_unique_id = f"gicisky_{self._identifier}_write_lock"
+        self._hass = hass
+        self._entry_id = entry.entry_id
+        self._is_on = False
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, self._address)},
+            name=f"Gicisky {self._identifier}",
+            manufacturer="Gicisky",
+        )
+
+    @cached_property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        return self._is_on
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn on the write lock."""
+        self._is_on = True
+        self._hass.data[DOMAIN][self._entry_id][WRITE_LOCK] = True
+
+        # Save to config entry data for persistence
+        config_entry = self._hass.config_entries.async_get_entry(self._entry_id)
+        if config_entry:
+            data = {**config_entry.data, WRITE_LOCK: True}
+            self._hass.config_entries.async_update_entry(config_entry, data=data)
+
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn off the write lock."""
+        self._is_on = False
+        self._hass.data[DOMAIN][self._entry_id][WRITE_LOCK] = False
+
+        # Save to config entry data for persistence
+        config_entry = self._hass.config_entries.async_get_entry(self._entry_id)
+        if config_entry:
+            data = {**config_entry.data, WRITE_LOCK: False}
+            self._hass.config_entries.async_update_entry(config_entry, data=data)
+
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Restore state when added to hass."""
+        await super().async_added_to_hass()
+
+        # Restore from config entry data (most reliable for config entities)
+        config_entry = self._hass.config_entries.async_get_entry(self._entry_id)
+        if config_entry and WRITE_LOCK in config_entry.data:
+            self._is_on = config_entry.data[WRITE_LOCK]
+        else:
+            # Fallback to RestoreEntity if not in config entry
+            last_state = await self.async_get_last_state()
+            if last_state is not None:
+                self._is_on = last_state.state == "on"
+            else:
+                # Default to False if no previous state
+                self._is_on = False
+
+        # Update hass.data with restored state
+        self._hass.data[DOMAIN][self._entry_id][WRITE_LOCK] = self._is_on


### PR DESCRIPTION
## Summary

Adds a **Write Lock** switch entity per device that, when enabled, allows the `gicisky.write` service to continue running normally (rendering images, updating HA state) while silently skipping the physical BLE write to the e-ink display.

## What changed

- **`switch.py`** — New `GiciskyWriteLockSwitch` entity (`SwitchEntity` + `RestoreEntity`). Appears under the device as a config-category switch (`mdi:lock`). State is persisted to config entry data so it survives HA restarts.
- **`__init__.py`** — In the `gicisky.write` service handler, after the dry-run check, a new guard reads the `WRITE_LOCK` flag. When active, the image coordinator is still updated (so the camera/image preview reflects the latest render) but the BLE write is skipped with an info-level log message.
- **`const.py`** — New `WRITE_LOCK = "write_lock"` constant; `SWITCH` added to the registered platforms list.

## Use case

Useful when you want automations to keep rendering and tracking what *would* be displayed (e.g. during testing, screen maintenance, or overnight to avoid unnecessary refreshes) without physically cycling the e-ink panel.

You won't need to adjust your write calls (to use dry run based on some conditions). All physical updates are blocked to prevent not required changes.