### PR TITLE
Add configurable write debounce support & new Write smart action to reduce impact

### DIFF
--- a/custom_components/gicisky/__init__.py
+++ b/custom_components/gicisky/__init__.py
@@ -25,6 +25,7 @@ from datetime import datetime
 
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceRegistry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.util.signal_type import SignalType
 from homeassistant.util.dt import now
 from homeassistant.exceptions import HomeAssistantError
@@ -35,9 +36,11 @@ from .const import (
     CONF_RETRY_COUNT,
     CONF_WRITE_DELAY_MS,
     CONF_PREVENT_DUPLICATE_SEND,
+    CONF_DEBOUNCE_MS,
     DEFAULT_RETRY_COUNT,
     DEFAULT_WRITE_DELAY_MS,
     DEFAULT_PREVENT_DUPLICATE_SEND,
+    DEFAULT_DEBOUNCE_MS,
     WRITE_LOCK,
 )
 from .coordinator import GiciskyPassiveBluetoothProcessorCoordinator
@@ -146,6 +149,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
     hass.data[DOMAIN][entry.entry_id]['duration_task'] = None
     hass.data[DOMAIN][entry.entry_id]['start_time'] = None
     hass.data[DOMAIN][entry.entry_id]['last_image_data'] = None
+
+    # Create write debouncer
+    options = {**entry.data, **entry.options}
+    debounce_ms = int(options.get(CONF_DEBOUNCE_MS, DEFAULT_DEBOUNCE_MS))
+    hass.data[DOMAIN][entry.entry_id]['write_debouncer'] = Debouncer(hass, _LOGGER, cooldown=debounce_ms / 1000.0, immediate=False)
+    hass.data[DOMAIN][entry.entry_id]['write_pending'] = False
+
     connectivity_coordinator.async_set_updated_data(False)
     duration_coordinator.async_set_updated_data(0.0)
     failure_coordinator.async_set_updated_data(0)
@@ -164,105 +174,127 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
     @callback
     # callback for the draw custom service
     async def writeservice(service: ServiceCall) -> None:
-        lock = hass.data[DOMAIN][LOCK]
-        async with lock:
-            device_ids = service.data.get("device_id")
-            if isinstance(device_ids, str):
-                device_ids = [device_ids]
+        device_ids = service.data.get("device_id")
+        if isinstance(device_ids, str):
+            device_ids = [device_ids]
 
-            dry_run = service.data.get("dry_run", False)
+        dry_run = service.data.get("dry_run", False)
 
-            # Process each device
-            for device_id in device_ids:
-                entry_id = await get_entry_id_from_device(hass, device_id)
-                config_entry = hass.config_entries.async_get_entry(entry_id)
-                options = {**config_entry.data, **config_entry.options}
-                max_retries = int(options.get(CONF_RETRY_COUNT, DEFAULT_RETRY_COUNT))
-                write_delay_ms = int(options.get(CONF_WRITE_DELAY_MS, DEFAULT_WRITE_DELAY_MS))
-                address = hass.data[DOMAIN][entry_id]['address']
-                data = hass.data[DOMAIN][entry_id]['data']
-                image_coordinator = hass.data[DOMAIN][entry_id]['image_coordinator']
-                preview_coordinator = hass.data[DOMAIN][entry_id]['preview_coordinator']
-                connectivity_coordinator = hass.data[DOMAIN][entry_id]['connectivity_coordinator']
-                duration_coordinator = hass.data[DOMAIN][entry_id]['duration_coordinator']
-                failure_coordinator = hass.data[DOMAIN][entry_id]['failure_coordinator']
-                last_failure_coordinator = hass.data[DOMAIN][entry_id]['last_failure_coordinator']
-                ble_device = async_ble_device_from_address(hass, address)
+        # Process each device
+        for device_id in device_ids:
+            entry_id = await get_entry_id_from_device(hass, device_id)
+            config_entry = hass.config_entries.async_get_entry(entry_id)
+            options = {**config_entry.data, **config_entry.options}
+            max_retries = int(options.get(CONF_RETRY_COUNT, DEFAULT_RETRY_COUNT))
+            write_delay_ms = int(options.get(CONF_WRITE_DELAY_MS, DEFAULT_WRITE_DELAY_MS))
+            address = hass.data[DOMAIN][entry_id]['address']
+            data = hass.data[DOMAIN][entry_id]['data']
+            image_coordinator = hass.data[DOMAIN][entry_id]['image_coordinator']
+            preview_coordinator = hass.data[DOMAIN][entry_id]['preview_coordinator']
+            connectivity_coordinator = hass.data[DOMAIN][entry_id]['connectivity_coordinator']
+            duration_coordinator = hass.data[DOMAIN][entry_id]['duration_coordinator']
+            failure_coordinator = hass.data[DOMAIN][entry_id]['failure_coordinator']
+            last_failure_coordinator = hass.data[DOMAIN][entry_id]['last_failure_coordinator']
+            ble_device = async_ble_device_from_address(hass, address)
 
-                if data.device is None or data.device.width is None or data.device.height is None:
-                    _LOGGER.error(f"Cannot write to {address}: Device not found or no BLE data received yet. Please check if the device is powered on and in range.")
-                    continue
+            if data.device is None or data.device.width is None or data.device.height is None or ble_device is None:
+                _LOGGER.error(f"Cannot write to {address}: Device not found or no BLE data received yet. Please check if the device is powered on and in range.")
+                continue
 
-                threshold = int(service.data.get("threshold", 128))
-                red_threshold = int(service.data.get("red_threshold", 128))
-                image = await hass.async_add_executor_job(render_image, entry_id, data.device, service, hass)
-                image_bytes = BytesIO()
-                image.save(image_bytes, "PNG")
-                preview_coordinator.async_set_updated_data(image_bytes.getvalue())
+            threshold = int(service.data.get("threshold", 128))
+            red_threshold = int(service.data.get("red_threshold", 128))
+            image = await hass.async_add_executor_job(render_image, entry_id, data.device, service, hass)
+            image_bytes = BytesIO()
+            image.save(image_bytes, "PNG")
+            preview_coordinator.async_set_updated_data(image_bytes.getvalue())
 
-                # Check for duplicate image
-                prevent_duplicate_send = options.get(CONF_PREVENT_DUPLICATE_SEND, DEFAULT_PREVENT_DUPLICATE_SEND)
-                current_image_data = image_bytes.getvalue()
-                last_image_data = hass.data[DOMAIN][entry_id].get('last_image_data')
+            # Check for duplicate image
+            prevent_duplicate_send = options.get(CONF_PREVENT_DUPLICATE_SEND, DEFAULT_PREVENT_DUPLICATE_SEND)
+            current_image_data = image_bytes.getvalue()
+            last_image_data = hass.data[DOMAIN][entry_id].get('last_image_data')
 
-                if prevent_duplicate_send and current_image_data == last_image_data:
-                    _LOGGER.info(f"Skipping duplicate image for {address}")
-                    continue
+            if prevent_duplicate_send and current_image_data == last_image_data:
+                _LOGGER.info(f"Skipping duplicate image for {address}")
+                continue
 
-                hass.data[DOMAIN][entry_id]['last_image_data'] = current_image_data
+            hass.data[DOMAIN][entry_id]['last_image_data'] = current_image_data
 
-                # If dry_run is True, skip sending to the actual device
-                if dry_run:
-                    continue
+            # If dry_run is True, skip sending to the actual device
+            if dry_run:
+                continue
 
-                # If write lock is on, update image coordinator but skip BLE
-                if hass.data[DOMAIN][entry_id].get(WRITE_LOCK, False):
-                    _LOGGER.info(f"Write lock active for {address} — skipping BLE write")
-                    image_coordinator.async_set_updated_data(current_image_data)
-                    continue
+            # If write lock is on, update image coordinator but skip BLE
+            if hass.data[DOMAIN][entry_id].get(WRITE_LOCK, False):
+                _LOGGER.info(f"Write lock active for {address} — skipping BLE write")
+                image_coordinator.async_set_updated_data(current_image_data)
+                continue
 
-                # Start duration tracking
-                hass.data[DOMAIN][entry_id]['start_time'] = time.monotonic()
-                duration_coordinator.async_set_updated_data(0.0)
-                connectivity_coordinator.async_set_updated_data(True)
-                
-                # Start background task to update duration
-                duration_task = asyncio.create_task(update_duration_loop(entry_id))
-                hass.data[DOMAIN][entry_id]['duration_task'] = duration_task
-                
-                try:
-                    for attempt in range(1, max_retries + 1):
-                        success = await update_image(ble_device, data.device, image, threshold, red_threshold, attempt=attempt, write_delay_ms=write_delay_ms)
-                        if success:
-                            image_coordinator.async_set_updated_data(image_bytes.getvalue())
-                            break
+            # Get debounce delay
+            debounce_ms = int(service.data.get("debounce_override_ms", options.get(CONF_DEBOUNCE_MS, DEFAULT_DEBOUNCE_MS)))
 
-                        _LOGGER.warning(f"Write failed to {address} (attempt {attempt}/{max_retries})")
-                        if attempt < max_retries:
-                            await sleep(1)
-                        else:
-                            # Update failure sensors
-                            current_count = failure_coordinator.data if failure_coordinator.data else 0
-                            failure_coordinator.async_set_updated_data(current_count + 1)
-                            last_failure_coordinator.async_set_updated_data(now())
-                            raise HomeAssistantError(f"Failed to write to {address} after {max_retries} attempts")
-                finally:
-                    # Stop duration tracking
-                    duration_task.cancel()
+            # Inline BLE write function
+            async def do_ble_write(_entry_id=entry_id, _address=address, _image_coordinator=image_coordinator, _current_image_data=current_image_data, _duration_coordinator=duration_coordinator, _connectivity_coordinator=connectivity_coordinator, _ble_device=ble_device, _data=data, _image=image, _threshold=threshold, _red_threshold=red_threshold, _max_retries=max_retries, _write_delay_ms=write_delay_ms, _failure_coordinator=failure_coordinator, _last_failure_coordinator=last_failure_coordinator):
+                async with hass.data[DOMAIN][LOCK]:
+                    hass.data[DOMAIN][_entry_id]['write_pending'] = False
+                    if hass.data[DOMAIN][_entry_id].get(WRITE_LOCK, False):
+                        _LOGGER.info(f"Write lock active for {_address} — skipping BLE write")
+                        _image_coordinator.async_set_updated_data(_current_image_data)
+                        return
+
+                    # Start duration tracking
+                    hass.data[DOMAIN][_entry_id]['start_time'] = time.monotonic()
+                    _duration_coordinator.async_set_updated_data(0.0)
+                    _connectivity_coordinator.async_set_updated_data(True)
+                    # Start background task to update duration
+                    duration_task = asyncio.create_task(update_duration_loop(_entry_id))
+                    hass.data[DOMAIN][_entry_id]['duration_task'] = duration_task
+
                     try:
-                        await duration_task
-                    except asyncio.CancelledError:
-                        pass
-                    
-                    # Update final elapsed time
-                    start_time = hass.data[DOMAIN][entry_id].get('start_time')
-                    if start_time is not None:
-                        elapsed_time = round(time.monotonic() - start_time, 2)
-                        duration_coordinator.async_set_updated_data(elapsed_time)
-                    
-                    hass.data[DOMAIN][entry_id]['start_time'] = None
-                    hass.data[DOMAIN][entry_id]['duration_task'] = None
-                    connectivity_coordinator.async_set_updated_data(False)
+                        for attempt in range(1, _max_retries + 1):
+                            success = await update_image(_ble_device, _data.device, _image, _threshold, _red_threshold, attempt=attempt, write_delay_ms=_write_delay_ms)
+                            if success:
+                                _image_coordinator.async_set_updated_data(_current_image_data)
+                                break
+                            _LOGGER.warning(f"Write failed to {_address} (attempt {attempt}/{_max_retries})")
+                            if attempt < _max_retries:
+                                await sleep(1)
+                            else:
+                                # Update failure sensors
+                                current_count = _failure_coordinator.data if _failure_coordinator.data else 0
+                                _failure_coordinator.async_set_updated_data(current_count + 1)
+                                _last_failure_coordinator.async_set_updated_data(now())
+                                raise HomeAssistantError(f"Failed to write to {_address} after {_max_retries} attempts")
+                    finally:
+                        # Stop duration tracking
+                        duration_task.cancel()
+                        try:
+                            await duration_task
+                        except asyncio.CancelledError:
+                            pass
+                        # Update final elapsed time
+                        start_time = hass.data[DOMAIN][_entry_id].get('start_time')
+                        if start_time is not None:
+                            elapsed_time = round(time.monotonic() - start_time, 2)
+                            _duration_coordinator.async_set_updated_data(elapsed_time)
+                        hass.data[DOMAIN][_entry_id]['start_time'] = None
+                        hass.data[DOMAIN][_entry_id]['duration_task'] = None
+                        _connectivity_coordinator.async_set_updated_data(False)
+
+            # Execute with or without debouncing
+            debouncer = hass.data[DOMAIN][entry_id]['write_debouncer']
+            if debounce_ms > 0:
+                new_cooldown = debounce_ms / 1000.0
+                if debouncer.cooldown != new_cooldown:
+                    debouncer.cooldown = new_cooldown
+                had_pending = hass.data[DOMAIN][entry_id]['write_pending']
+                hass.data[DOMAIN][entry_id]['write_pending'] = True
+                if had_pending:
+                    _LOGGER.info(f"Cancelled pending write for {address}, rescheduled with {debounce_ms}ms delay")
+                debouncer.function = do_ble_write
+                debouncer.async_schedule_call()
+            else:
+                await do_ble_write()
+
 
     # register the services
     hass.services.async_register(DOMAIN, "write", writeservice)
@@ -276,6 +308,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> 
     """Unload a config entry."""
     if len(hass.config_entries.async_entries(DOMAIN)) == 1:
         hass.services.async_remove(DOMAIN, "write")
+
+    # Cleanup write debouncer
+    if entry.entry_id in hass.data.get(DOMAIN, {}):
+        if write_debouncer := hass.data[DOMAIN][entry.entry_id].get('write_debouncer'):
+            write_debouncer.async_shutdown()
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     

--- a/custom_components/gicisky/__init__.py
+++ b/custom_components/gicisky/__init__.py
@@ -174,6 +174,103 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
     @callback
     # callback for the draw custom service
     async def writeservice(service: ServiceCall) -> None:
+        lock = hass.data[DOMAIN][LOCK]
+        async with lock:
+            device_ids = service.data.get("device_id")
+            if isinstance(device_ids, str):
+                device_ids = [device_ids]
+
+            dry_run = service.data.get("dry_run", False)
+
+            # Process each device
+            for device_id in device_ids:
+                entry_id = await get_entry_id_from_device(hass, device_id)
+                config_entry = hass.config_entries.async_get_entry(entry_id)
+                options = {**config_entry.data, **config_entry.options}
+                max_retries = int(options.get(CONF_RETRY_COUNT, DEFAULT_RETRY_COUNT))
+                write_delay_ms = int(options.get(CONF_WRITE_DELAY_MS, DEFAULT_WRITE_DELAY_MS))
+                address = hass.data[DOMAIN][entry_id]['address']
+                data = hass.data[DOMAIN][entry_id]['data']
+                image_coordinator = hass.data[DOMAIN][entry_id]['image_coordinator']
+                preview_coordinator = hass.data[DOMAIN][entry_id]['preview_coordinator']
+                connectivity_coordinator = hass.data[DOMAIN][entry_id]['connectivity_coordinator']
+                duration_coordinator = hass.data[DOMAIN][entry_id]['duration_coordinator']
+                failure_coordinator = hass.data[DOMAIN][entry_id]['failure_coordinator']
+                last_failure_coordinator = hass.data[DOMAIN][entry_id]['last_failure_coordinator']
+                ble_device = async_ble_device_from_address(hass, address)
+
+                if data.device is None or data.device.width is None or data.device.height is None:
+                    _LOGGER.error(f"Cannot write to {address}: Device not found or no BLE data received yet. Please check if the device is powered on and in range.")
+                    continue
+
+                threshold = int(service.data.get("threshold", 128))
+                red_threshold = int(service.data.get("red_threshold", 128))
+                image = await hass.async_add_executor_job(render_image, entry_id, data.device, service, hass)
+                image_bytes = BytesIO()
+                image.save(image_bytes, "PNG")
+                preview_coordinator.async_set_updated_data(image_bytes.getvalue())
+
+                # Check for duplicate image
+                prevent_duplicate_send = options.get(CONF_PREVENT_DUPLICATE_SEND, DEFAULT_PREVENT_DUPLICATE_SEND)
+                current_image_data = image_bytes.getvalue()
+                last_image_data = hass.data[DOMAIN][entry_id].get('last_image_data')
+
+                if prevent_duplicate_send and current_image_data == last_image_data:
+                    _LOGGER.info(f"Skipping duplicate image for {address}")
+                    continue
+
+                hass.data[DOMAIN][entry_id]['last_image_data'] = current_image_data
+
+                # If dry_run is True, skip sending to the actual device
+                if dry_run:
+                    continue
+
+                # Start duration tracking
+                hass.data[DOMAIN][entry_id]['start_time'] = time.monotonic()
+                duration_coordinator.async_set_updated_data(0.0)
+                connectivity_coordinator.async_set_updated_data(True)
+                
+                # Start background task to update duration
+                duration_task = asyncio.create_task(update_duration_loop(entry_id))
+                hass.data[DOMAIN][entry_id]['duration_task'] = duration_task
+                
+                try:
+                    for attempt in range(1, max_retries + 1):
+                        success = await update_image(ble_device, data.device, image, threshold, red_threshold, attempt=attempt, write_delay_ms=write_delay_ms)
+                        if success:
+                            image_coordinator.async_set_updated_data(image_bytes.getvalue())
+                            break
+
+                        _LOGGER.warning(f"Write failed to {address} (attempt {attempt}/{max_retries})")
+                        if attempt < max_retries:
+                            await sleep(1)
+                        else:
+                            # Update failure sensors
+                            current_count = failure_coordinator.data if failure_coordinator.data else 0
+                            failure_coordinator.async_set_updated_data(current_count + 1)
+                            last_failure_coordinator.async_set_updated_data(now())
+                            raise HomeAssistantError(f"Failed to write to {address} after {max_retries} attempts")
+                finally:
+                    # Stop duration tracking
+                    duration_task.cancel()
+                    try:
+                        await duration_task
+                    except asyncio.CancelledError:
+                        pass
+                    
+                    # Update final elapsed time
+                    start_time = hass.data[DOMAIN][entry_id].get('start_time')
+                    if start_time is not None:
+                        elapsed_time = round(time.monotonic() - start_time, 2)
+                        duration_coordinator.async_set_updated_data(elapsed_time)
+                    
+                    hass.data[DOMAIN][entry_id]['start_time'] = None
+                    hass.data[DOMAIN][entry_id]['duration_task'] = None
+                    connectivity_coordinator.async_set_updated_data(False)
+
+    @callback
+    # callback for the smart write service
+    async def writesmartservice(service: ServiceCall) -> None:
         device_ids = service.data.get("device_id")
         if isinstance(device_ids, str):
             device_ids = [device_ids]
@@ -298,6 +395,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
 
     # register the services
     hass.services.async_register(DOMAIN, "write", writeservice)
+    hass.services.async_register(DOMAIN, "write_smart", writesmartservice)
 
     # only start after all platforms have had a chance to subscribe
     entry.async_on_unload(bt_coordinator.async_start())
@@ -308,6 +406,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> 
     """Unload a config entry."""
     if len(hass.config_entries.async_entries(DOMAIN)) == 1:
         hass.services.async_remove(DOMAIN, "write")
+        hass.services.async_remove(DOMAIN, "write_smart")
 
     # Cleanup write debouncer
     if entry.entry_id in hass.data.get(DOMAIN, {}):

--- a/custom_components/gicisky/config_flow.py
+++ b/custom_components/gicisky/config_flow.py
@@ -33,9 +33,11 @@ from .const import (
     CONF_RETRY_COUNT,
     CONF_WRITE_DELAY_MS,
     CONF_PREVENT_DUPLICATE_SEND,
+    CONF_DEBOUNCE_MS,
     DEFAULT_RETRY_COUNT,
     DEFAULT_WRITE_DELAY_MS,
     DEFAULT_PREVENT_DUPLICATE_SEND,
+    DEFAULT_DEBOUNCE_MS,
 )
 
 
@@ -61,6 +63,15 @@ OPTIONS_SCHEMA = {
         CONF_PREVENT_DUPLICATE_SEND,
         default=DEFAULT_PREVENT_DUPLICATE_SEND,
     ): bool,
+    vol.Required(CONF_DEBOUNCE_MS, default=DEFAULT_DEBOUNCE_MS): NumberSelector(
+        NumberSelectorConfig(
+            min=0,
+            max=120000,
+            step=1000,
+            mode=NumberSelectorMode.SLIDER,
+            unit_of_measurement="ms",
+        )
+    ),
 }
 
 

--- a/custom_components/gicisky/const.py
+++ b/custom_components/gicisky/const.py
@@ -9,11 +9,13 @@ LOCK = "lock"
 CONF_RETRY_COUNT = "retry_count"
 CONF_WRITE_DELAY_MS = "write_delay_ms"
 CONF_PREVENT_DUPLICATE_SEND = "prevent_duplicate_send"
+CONF_DEBOUNCE_MS = "debounce_ms"
 
 # Defaults
 DEFAULT_RETRY_COUNT = 3
 DEFAULT_WRITE_DELAY_MS = 0
 DEFAULT_PREVENT_DUPLICATE_SEND = False
+DEFAULT_DEBOUNCE_MS = 0
 
 # Runtime state keys
 WRITE_LOCK = "write_lock"

--- a/custom_components/gicisky/services.yaml
+++ b/custom_components/gicisky/services.yaml
@@ -72,3 +72,14 @@ write:
       example: 'false'
       selector:
         boolean:
+    debounce_override_ms:
+      name: Debounce Override
+      description: "Override configured debounce delay for this call (0 = immediate)"
+      required: false
+      example: 5000
+      selector:
+        number:
+          min: 0
+          max: 120000
+          step: 1000
+          unit_of_measurement: ms

--- a/custom_components/gicisky/services.yaml
+++ b/custom_components/gicisky/services.yaml
@@ -72,6 +72,80 @@ write:
       example: 'false'
       selector:
         boolean:
+write_smart:
+  name: Write Smart Label
+  description: Write Gicisky Label image with debounce and duplicate prevention
+  target:
+    device:
+      manufacturer: Gicisky
+  fields:
+    payload:
+      name: Payload
+      description: Paylod to draw
+      required: true
+      example: |
+        - type: text
+          value: Hello World!
+          x: 10
+          y: 10
+          size: 40
+      default:
+        - type: text
+          value: Hello World!
+          x: 10
+          y: 10
+          size: 40
+      selector:
+        object:
+    rotate:
+      name: Rotate
+      description: "Label Rotation (0, 90, 180, 270), default: 0"
+      required: false
+      example: '0'
+      selector:
+        number:
+          min: 0
+          max: 270
+          step: 90
+    background:
+      name: Background
+      description: "Background Color (white, black, red), default: white"
+      required: false
+      example: white
+      selector:
+        select:
+          options:
+            - "white"
+            - "black"
+            - "red"
+            - "yellow"
+    threshold:
+      name: Black Threshold
+      description: "Black binary threshold (0 ~ 255), default: 128"
+      required: false
+      example: 128
+      selector:
+        number:
+          min: 0
+          max: 255
+          step: 1
+    red_threshold:
+      name: Red Threshold
+      description: "Red binary threshold (0 ~ 255), default: 128"
+      required: false
+      example: 128
+      selector:
+        number:
+          min: 0
+          max: 255
+          step: 1
+    dry_run:
+      name: Dry Run
+      description: "Generate image without sending to device"
+      required: false
+      example: 'false'
+      selector:
+        boolean:
     debounce_override_ms:
       name: Debounce Override
       description: "Override configured debounce delay for this call (0 = immediate)"

--- a/custom_components/gicisky/strings.json
+++ b/custom_components/gicisky/strings.json
@@ -26,7 +26,11 @@
         "data": {
           "retry_count": "Retry Count",
           "write_delay_ms": "Write Delay (ms)",
-          "prevent_duplicate_send": "Prevent Duplicate Send"
+          "prevent_duplicate_send": "Prevent Duplicate Send",
+          "debounce_ms": "Debounce Delay (ms)"
+        },
+        "data_description": {
+          "debounce_ms": "Delay before writing to device. New writes cancel pending ones. 0 = disabled (immediate write)."
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add configurable debounce delay for BLE writes, preventing rapid repeated writes to e-ink displays
- New `debounce_ms` option in integration settings (0–120000ms slider, default 0 = disabled)
- New `debounce_override_ms` service parameter to override the configured delay per call
- BLE write logic moved into `do_ble_write()` with its own lock acquisition, so debounced writes remain serialized
- Add `ble_device is None` safety check before attempting writes

## Use case 1 — Skipping short-lived changes
A motion sensor turns on my hallway light for 30 seconds. My e-ink display tracks which lights are on. Without debounce, it updates twice for every walk past the sensor. With `debounce_ms: 60000`, these brief on/off changes settle before the delay expires and the display never bothers updating for a light that was only on for a moment.

## Use case 2 — Frequent sensor updates
A price tag displays a temperature sensor that updates every few seconds. Without debounce, every change triggers a slow BLE write to the display. With `debounce_ms: 10000`, the integration waits 10 seconds for changes to settle before sending. Only the last image gets written, saving time and battery.

## Screenshot
Example of debouncing log:

<img width="1461" height="176" alt="image" src="https://github.com/user-attachments/assets/f6ee311d-ffe7-47db-a1a2-66cc13890dc7" />

Action
<img width="1326" height="326" alt="image" src="https://github.com/user-attachments/assets/0218f4ca-d4b3-40a6-be0c-5ed909c26f59" />
