### PR TITLE
Add Last Write and Last Preview timestamp sensors

### DIFF
--- a/custom_components/gicisky/__init__.py
+++ b/custom_components/gicisky/__init__.py
@@ -139,6 +139,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
         _LOGGER,
         name=DOMAIN,
     )
+    last_write_coordinator: DataUpdateCoordinator[datetime | None] = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=DOMAIN,
+    )
+    last_preview_coordinator: DataUpdateCoordinator[datetime | None] = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=DOMAIN,
+    )
     entry.runtime_data = bt_coordinator
     hass.data[DOMAIN][entry.entry_id]['image_coordinator'] = image_coordinator
     hass.data[DOMAIN][entry.entry_id]['preview_coordinator'] = preview_coordinator
@@ -146,6 +156,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
     hass.data[DOMAIN][entry.entry_id]['duration_coordinator'] = duration_coordinator
     hass.data[DOMAIN][entry.entry_id]['failure_coordinator'] = failure_coordinator
     hass.data[DOMAIN][entry.entry_id]['last_failure_coordinator'] = last_failure_coordinator
+    hass.data[DOMAIN][entry.entry_id]['last_write_coordinator'] = last_write_coordinator
+    hass.data[DOMAIN][entry.entry_id]['last_preview_coordinator'] = last_preview_coordinator
     hass.data[DOMAIN][entry.entry_id]['duration_task'] = None
     hass.data[DOMAIN][entry.entry_id]['start_time'] = None
     hass.data[DOMAIN][entry.entry_id]['last_image_data'] = None
@@ -160,6 +172,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
     duration_coordinator.async_set_updated_data(0.0)
     failure_coordinator.async_set_updated_data(0)
     last_failure_coordinator.async_set_updated_data(None)
+    last_write_coordinator.async_set_updated_data(None)
+    last_preview_coordinator.async_set_updated_data(None)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def update_duration_loop(entry_id: str):
@@ -212,6 +226,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
         image.save(image_bytes, "PNG")
         current_image_data = image_bytes.getvalue()
         preview_coordinator.async_set_updated_data(current_image_data)
+        hass.data[DOMAIN][entry_id]['last_preview_coordinator'].async_set_updated_data(now())
 
         return {
             "entry_id": entry_id,
@@ -223,6 +238,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
             "duration_coordinator": duration_coordinator,
             "failure_coordinator": failure_coordinator,
             "last_failure_coordinator": last_failure_coordinator,
+            "last_write_coordinator": hass.data[DOMAIN][entry_id]['last_write_coordinator'],
             "ble_device": ble_device,
             "threshold": threshold,
             "red_threshold": red_threshold,
@@ -242,6 +258,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
         duration_coordinator = context["duration_coordinator"]
         failure_coordinator = context["failure_coordinator"]
         last_failure_coordinator = context["last_failure_coordinator"]
+        last_write_coordinator = context["last_write_coordinator"]
         ble_device = context["ble_device"]
         threshold = context["threshold"]
         red_threshold = context["red_threshold"]
@@ -262,6 +279,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
                 success = await update_image(ble_device, data.device, image, threshold, red_threshold, attempt=attempt, write_delay_ms=write_delay_ms)
                 if success:
                     image_coordinator.async_set_updated_data(current_image_data)
+                    last_write_coordinator.async_set_updated_data(now())
                     return
 
                 _LOGGER.warning(f"Write failed to {address} (attempt {attempt}/{max_retries})")

--- a/custom_components/gicisky/sensor.py
+++ b/custom_components/gicisky/sensor.py
@@ -460,10 +460,14 @@ async def async_setup_entry(
     duration_coordinator = hass.data[DOMAIN][entry.entry_id]["duration_coordinator"]
     failure_coordinator = hass.data[DOMAIN][entry.entry_id]["failure_coordinator"]
     last_failure_coordinator = hass.data[DOMAIN][entry.entry_id]["last_failure_coordinator"]
+    last_write_coordinator = hass.data[DOMAIN][entry.entry_id]["last_write_coordinator"]
+    last_preview_coordinator = hass.data[DOMAIN][entry.entry_id]["last_preview_coordinator"]
     async_add_entities([
         GiciskyDurationSensorEntity(hass, entry, duration_coordinator),
         GiciskyFailureCountSensorEntity(hass, entry, failure_coordinator),
         GiciskyLastFailureTimeSensorEntity(hass, entry, last_failure_coordinator),
+        GiciskyLastWriteTimeSensorEntity(hass, entry, last_write_coordinator),
+        GiciskyLastPreviewTimeSensorEntity(hass, entry, last_preview_coordinator),
     ])
 
 
@@ -614,6 +618,94 @@ class GiciskyLastFailureTimeSensorEntity(
         self._attr_name = f"Gicisky {self._identifier} Last Failure Time"
         self._attr_unique_id = f"gicisky_{self._identifier}_last_failure_time"
         self._native_value: datetime | None = None
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the native value."""
+        return self.coordinator.data
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, self._address)},
+            name=f"Gicisky {self._identifier}",
+            manufacturer="Gicisky",
+        )
+
+    @cached_property
+    def available(self) -> bool:
+        """Entity always available."""
+        return True
+
+
+class GiciskyLastWriteTimeSensorEntity(
+    CoordinatorEntity[DataUpdateCoordinator[datetime | None]],
+    SensorEntity,
+):
+    """Representation of a Gicisky BLE last write time sensor."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:clock-check"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator[datetime | None],
+    ) -> None:
+        """Initialize the last write time sensor."""
+        CoordinatorEntity.__init__(self, coordinator)
+        address = hass.data[DOMAIN][entry.entry_id]["address"]
+        self._address = address
+        self._identifier = address.replace(":", "")[-8:]
+        self._attr_name = f"Gicisky {self._identifier} Last Write"
+        self._attr_unique_id = f"gicisky_{self._identifier}_last_write_time"
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the native value."""
+        return self.coordinator.data
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, self._address)},
+            name=f"Gicisky {self._identifier}",
+            manufacturer="Gicisky",
+        )
+
+    @cached_property
+    def available(self) -> bool:
+        """Entity always available."""
+        return True
+
+
+class GiciskyLastPreviewTimeSensorEntity(
+    CoordinatorEntity[DataUpdateCoordinator[datetime | None]],
+    SensorEntity,
+):
+    """Representation of a Gicisky BLE last preview time sensor."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:clock-edit-outline"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator[datetime | None],
+    ) -> None:
+        """Initialize the last preview time sensor."""
+        CoordinatorEntity.__init__(self, coordinator)
+        address = hass.data[DOMAIN][entry.entry_id]["address"]
+        self._address = address
+        self._identifier = address.replace(":", "")[-8:]
+        self._attr_name = f"Gicisky {self._identifier} Last Preview"
+        self._attr_unique_id = f"gicisky_{self._identifier}_last_preview_time"
 
     @property
     def native_value(self) -> datetime | None:


### PR DESCRIPTION
Adds two new diagnostic timestamp sensors per device:

- **Last Write** — updated when a BLE write succeeds (image sent to device)
- **Last Preview** — updated on every render, including dry runs

Both sensors work with `write` and `write_guarded` services.
Useful for automations and dashboards to track when the display was last physically updated vs last rendered.