### PR TITLE
Add Preview Content image entity

### DIFF
--- a/custom_components/gicisky/__init__.py
+++ b/custom_components/gicisky/__init__.py
@@ -139,6 +139,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
         _LOGGER,
         name=DOMAIN,
     )
+    last_write_coordinator: DataUpdateCoordinator[datetime | None] = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=DOMAIN,
+    )
+    last_preview_coordinator: DataUpdateCoordinator[datetime | None] = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=DOMAIN,
+    )
     entry.runtime_data = bt_coordinator
     hass.data[DOMAIN][entry.entry_id]['image_coordinator'] = image_coordinator
     hass.data[DOMAIN][entry.entry_id]['preview_coordinator'] = preview_coordinator
@@ -146,6 +156,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
     hass.data[DOMAIN][entry.entry_id]['duration_coordinator'] = duration_coordinator
     hass.data[DOMAIN][entry.entry_id]['failure_coordinator'] = failure_coordinator
     hass.data[DOMAIN][entry.entry_id]['last_failure_coordinator'] = last_failure_coordinator
+    hass.data[DOMAIN][entry.entry_id]['last_write_coordinator'] = last_write_coordinator
+    hass.data[DOMAIN][entry.entry_id]['last_preview_coordinator'] = last_preview_coordinator
     hass.data[DOMAIN][entry.entry_id]['duration_task'] = None
     hass.data[DOMAIN][entry.entry_id]['start_time'] = None
     hass.data[DOMAIN][entry.entry_id]['last_image_data'] = None
@@ -160,6 +172,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
     duration_coordinator.async_set_updated_data(0.0)
     failure_coordinator.async_set_updated_data(0)
     last_failure_coordinator.async_set_updated_data(None)
+    last_write_coordinator.async_set_updated_data(None)
+    last_preview_coordinator.async_set_updated_data(None)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def update_duration_loop(entry_id: str):
@@ -212,6 +226,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
         image.save(image_bytes, "PNG")
         current_image_data = image_bytes.getvalue()
         preview_coordinator.async_set_updated_data(current_image_data)
+        hass.data[DOMAIN][entry_id]['last_preview_coordinator'].async_set_updated_data(now())
 
         return {
             "entry_id": entry_id,
@@ -223,6 +238,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
             "duration_coordinator": duration_coordinator,
             "failure_coordinator": failure_coordinator,
             "last_failure_coordinator": last_failure_coordinator,
+            "last_write_coordinator": hass.data[DOMAIN][entry_id]['last_write_coordinator'],
             "ble_device": ble_device,
             "threshold": threshold,
             "red_threshold": red_threshold,
@@ -242,6 +258,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
         duration_coordinator = context["duration_coordinator"]
         failure_coordinator = context["failure_coordinator"]
         last_failure_coordinator = context["last_failure_coordinator"]
+        last_write_coordinator = context["last_write_coordinator"]
         ble_device = context["ble_device"]
         threshold = context["threshold"]
         red_threshold = context["red_threshold"]
@@ -262,6 +279,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
                 success = await update_image(ble_device, data.device, image, threshold, red_threshold, attempt=attempt, write_delay_ms=write_delay_ms)
                 if success:
                     image_coordinator.async_set_updated_data(current_image_data)
+                    last_write_coordinator.async_set_updated_data(now())
                     return
 
                 _LOGGER.warning(f"Write failed to {address} (attempt {attempt}/{max_retries})")

--- a/custom_components/gicisky/__init__.py
+++ b/custom_components/gicisky/__init__.py
@@ -139,16 +139,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
         _LOGGER,
         name=DOMAIN,
     )
-    last_write_coordinator: DataUpdateCoordinator[datetime | None] = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=DOMAIN,
-    )
-    last_preview_coordinator: DataUpdateCoordinator[datetime | None] = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=DOMAIN,
-    )
     entry.runtime_data = bt_coordinator
     hass.data[DOMAIN][entry.entry_id]['image_coordinator'] = image_coordinator
     hass.data[DOMAIN][entry.entry_id]['preview_coordinator'] = preview_coordinator
@@ -156,8 +146,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
     hass.data[DOMAIN][entry.entry_id]['duration_coordinator'] = duration_coordinator
     hass.data[DOMAIN][entry.entry_id]['failure_coordinator'] = failure_coordinator
     hass.data[DOMAIN][entry.entry_id]['last_failure_coordinator'] = last_failure_coordinator
-    hass.data[DOMAIN][entry.entry_id]['last_write_coordinator'] = last_write_coordinator
-    hass.data[DOMAIN][entry.entry_id]['last_preview_coordinator'] = last_preview_coordinator
     hass.data[DOMAIN][entry.entry_id]['duration_task'] = None
     hass.data[DOMAIN][entry.entry_id]['start_time'] = None
     hass.data[DOMAIN][entry.entry_id]['last_image_data'] = None
@@ -172,8 +160,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
     duration_coordinator.async_set_updated_data(0.0)
     failure_coordinator.async_set_updated_data(0)
     last_failure_coordinator.async_set_updated_data(None)
-    last_write_coordinator.async_set_updated_data(None)
-    last_preview_coordinator.async_set_updated_data(None)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def update_duration_loop(entry_id: str):
@@ -226,7 +212,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
         image.save(image_bytes, "PNG")
         current_image_data = image_bytes.getvalue()
         preview_coordinator.async_set_updated_data(current_image_data)
-        hass.data[DOMAIN][entry_id]['last_preview_coordinator'].async_set_updated_data(now())
 
         return {
             "entry_id": entry_id,
@@ -238,7 +223,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
             "duration_coordinator": duration_coordinator,
             "failure_coordinator": failure_coordinator,
             "last_failure_coordinator": last_failure_coordinator,
-            "last_write_coordinator": hass.data[DOMAIN][entry_id]['last_write_coordinator'],
             "ble_device": ble_device,
             "threshold": threshold,
             "red_threshold": red_threshold,
@@ -258,7 +242,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
         duration_coordinator = context["duration_coordinator"]
         failure_coordinator = context["failure_coordinator"]
         last_failure_coordinator = context["last_failure_coordinator"]
-        last_write_coordinator = context["last_write_coordinator"]
         ble_device = context["ble_device"]
         threshold = context["threshold"]
         red_threshold = context["red_threshold"]
@@ -279,7 +262,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
                 success = await update_image(ble_device, data.device, image, threshold, red_threshold, attempt=attempt, write_delay_ms=write_delay_ms)
                 if success:
                     image_coordinator.async_set_updated_data(current_image_data)
-                    last_write_coordinator.async_set_updated_data(now())
                     return
 
                 _LOGGER.warning(f"Write failed to {address} (attempt {attempt}/{max_retries})")

--- a/custom_components/gicisky/__init__.py
+++ b/custom_components/gicisky/__init__.py
@@ -311,7 +311,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
             hass.data[DOMAIN][entry_id]['write_pending'] = False
             if hass.data[DOMAIN][entry_id].get(WRITE_LOCK, False):
                 _LOGGER.info(f"Write lock active for {address} — skipping BLE write")
-                image_coordinator.async_set_updated_data(current_image_data)
                 return
             await execute_write_core(context)
 
@@ -380,7 +379,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiciskyConfigEntry) -> b
             # If write lock is on, update image coordinator but skip BLE
             if hass.data[DOMAIN][entry_id].get(WRITE_LOCK, False):
                 _LOGGER.info(f"Write lock active for {address} — skipping BLE write")
-                image_coordinator.async_set_updated_data(current_image_data)
                 continue
 
             # Get debounce delay

--- a/custom_components/gicisky/image.py
+++ b/custom_components/gicisky/image.py
@@ -21,7 +21,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback
 ):
     image_coordinator = hass.data[DOMAIN][entry.entry_id]["image_coordinator"]
-    async_add_entities([GiciskyImageEntity(hass, entry, image_coordinator)])
+    preview_coordinator = hass.data[DOMAIN][entry.entry_id]["preview_coordinator"]
+    async_add_entities([
+        GiciskyImageEntity(hass, entry, image_coordinator),
+        GiciskyPreviewImageEntity(hass, entry, preview_coordinator),
+    ])
 
 class GiciskyImageEntity(CoordinatorEntity[DataUpdateCoordinator[bytes]], ImageEntity):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry, coordinator: DataUpdateCoordinator[bytes]):
@@ -69,5 +73,44 @@ class GiciskyImageEntity(CoordinatorEntity[DataUpdateCoordinator[bytes]], ImageE
         _LOGGER.debug("Updated image data")
         self._cached_image = Image(content_type="image/png", content=self.data)
 
+        self._attr_image_last_updated = dt_util.now()
+        super()._handle_coordinator_update()
+
+
+class GiciskyPreviewImageEntity(CoordinatorEntity[DataUpdateCoordinator[bytes]], ImageEntity):
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, coordinator: DataUpdateCoordinator[bytes]):
+        CoordinatorEntity.__init__(self, coordinator)
+        ImageEntity.__init__(self, hass)
+        address = hass.data[DOMAIN][entry.entry_id]['address']
+        self._address = address
+        self._identifier = address.replace(":", "")[-8:]
+        self._attr_name = f"Gicisky {self._identifier} Preview Content"
+        self._attr_unique_id = f"gicisky_{self._identifier}_preview_content_image"
+        self._attr_content_type = "image/png"
+        self._cached_image = Image(content_type="image/png", content=coordinator.data)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, self._address)},
+            name=f"Gicisky {self._identifier}",
+            manufacturer="Gicisky",
+        )
+
+    @cached_property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def data(self) -> bytes:
+        return self.coordinator.data
+
+    def image(self) -> bytes | None:
+        return self._cached_image.content
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        _LOGGER.debug("Updated preview image data")
+        self._cached_image = Image(content_type="image/png", content=self.data)
         self._attr_image_last_updated = dt_util.now()
         super()._handle_coordinator_update()

--- a/custom_components/gicisky/sensor.py
+++ b/custom_components/gicisky/sensor.py
@@ -460,10 +460,14 @@ async def async_setup_entry(
     duration_coordinator = hass.data[DOMAIN][entry.entry_id]["duration_coordinator"]
     failure_coordinator = hass.data[DOMAIN][entry.entry_id]["failure_coordinator"]
     last_failure_coordinator = hass.data[DOMAIN][entry.entry_id]["last_failure_coordinator"]
+    last_write_coordinator = hass.data[DOMAIN][entry.entry_id]["last_write_coordinator"]
+    last_preview_coordinator = hass.data[DOMAIN][entry.entry_id]["last_preview_coordinator"]
     async_add_entities([
         GiciskyDurationSensorEntity(hass, entry, duration_coordinator),
         GiciskyFailureCountSensorEntity(hass, entry, failure_coordinator),
         GiciskyLastFailureTimeSensorEntity(hass, entry, last_failure_coordinator),
+        GiciskyLastWriteTimeSensorEntity(hass, entry, last_write_coordinator),
+        GiciskyLastPreviewTimeSensorEntity(hass, entry, last_preview_coordinator),
     ])
 
 
@@ -614,6 +618,94 @@ class GiciskyLastFailureTimeSensorEntity(
         self._attr_name = f"Gicisky {self._identifier} Last Failure Time"
         self._attr_unique_id = f"gicisky_{self._identifier}_last_failure_time"
         self._native_value: datetime | None = None
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the native value."""
+        return self.coordinator.data
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, self._address)},
+            name=f"Gicisky {self._identifier}",
+            manufacturer="Gicisky",
+        )
+
+    @cached_property
+    def available(self) -> bool:
+        """Entity always available."""
+        return True
+
+
+class GiciskyLastWriteTimeSensorEntity(
+    CoordinatorEntity[DataUpdateCoordinator[datetime | None]],
+    SensorEntity,
+):
+    """Representation of a Gicisky BLE last write time sensor."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:clock-check"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator[datetime | None],
+    ) -> None:
+        """Initialize the last write time sensor."""
+        CoordinatorEntity.__init__(self, coordinator)
+        address = hass.data[DOMAIN][entry.entry_id]["address"]
+        self._address = address
+        self._identifier = address.replace(":", "")[-8:]
+        self._attr_name = f"Gicisky {self._identifier} Last Write"
+        self._attr_unique_id = f"gicisky_{self._identifier}_last_write_time"
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the native value."""
+        return self.coordinator.data
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, self._address)},
+            name=f"Gicisky {self._identifier}",
+            manufacturer="Gicisky",
+        )
+
+    @cached_property
+    def available(self) -> bool:
+        """Entity always available."""
+        return True
+
+
+class GiciskyLastPreviewTimeSensorEntity(
+    CoordinatorEntity[DataUpdateCoordinator[datetime | None]],
+    SensorEntity,
+):
+    """Representation of a Gicisky BLE last preview time sensor."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:clock-edit-outline"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator[datetime | None],
+    ) -> None:
+        """Initialize the last preview time sensor."""
+        CoordinatorEntity.__init__(self, coordinator)
+        address = hass.data[DOMAIN][entry.entry_id]["address"]
+        self._address = address
+        self._identifier = address.replace(":", "")[-8:]
+        self._attr_name = f"Gicisky {self._identifier} Last Preview"
+        self._attr_unique_id = f"gicisky_{self._identifier}_last_preview_time"
 
     @property
     def native_value(self) -> datetime | None:

--- a/custom_components/gicisky/sensor.py
+++ b/custom_components/gicisky/sensor.py
@@ -460,14 +460,10 @@ async def async_setup_entry(
     duration_coordinator = hass.data[DOMAIN][entry.entry_id]["duration_coordinator"]
     failure_coordinator = hass.data[DOMAIN][entry.entry_id]["failure_coordinator"]
     last_failure_coordinator = hass.data[DOMAIN][entry.entry_id]["last_failure_coordinator"]
-    last_write_coordinator = hass.data[DOMAIN][entry.entry_id]["last_write_coordinator"]
-    last_preview_coordinator = hass.data[DOMAIN][entry.entry_id]["last_preview_coordinator"]
     async_add_entities([
         GiciskyDurationSensorEntity(hass, entry, duration_coordinator),
         GiciskyFailureCountSensorEntity(hass, entry, failure_coordinator),
         GiciskyLastFailureTimeSensorEntity(hass, entry, last_failure_coordinator),
-        GiciskyLastWriteTimeSensorEntity(hass, entry, last_write_coordinator),
-        GiciskyLastPreviewTimeSensorEntity(hass, entry, last_preview_coordinator),
     ])
 
 
@@ -618,94 +614,6 @@ class GiciskyLastFailureTimeSensorEntity(
         self._attr_name = f"Gicisky {self._identifier} Last Failure Time"
         self._attr_unique_id = f"gicisky_{self._identifier}_last_failure_time"
         self._native_value: datetime | None = None
-
-    @property
-    def native_value(self) -> datetime | None:
-        """Return the native value."""
-        return self.coordinator.data
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        return DeviceInfo(
-            connections={(CONNECTION_BLUETOOTH, self._address)},
-            name=f"Gicisky {self._identifier}",
-            manufacturer="Gicisky",
-        )
-
-    @cached_property
-    def available(self) -> bool:
-        """Entity always available."""
-        return True
-
-
-class GiciskyLastWriteTimeSensorEntity(
-    CoordinatorEntity[DataUpdateCoordinator[datetime | None]],
-    SensorEntity,
-):
-    """Representation of a Gicisky BLE last write time sensor."""
-
-    _attr_device_class = SensorDeviceClass.TIMESTAMP
-    _attr_icon = "mdi:clock-check"
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        entry: ConfigEntry,
-        coordinator: DataUpdateCoordinator[datetime | None],
-    ) -> None:
-        """Initialize the last write time sensor."""
-        CoordinatorEntity.__init__(self, coordinator)
-        address = hass.data[DOMAIN][entry.entry_id]["address"]
-        self._address = address
-        self._identifier = address.replace(":", "")[-8:]
-        self._attr_name = f"Gicisky {self._identifier} Last Write"
-        self._attr_unique_id = f"gicisky_{self._identifier}_last_write_time"
-
-    @property
-    def native_value(self) -> datetime | None:
-        """Return the native value."""
-        return self.coordinator.data
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        return DeviceInfo(
-            connections={(CONNECTION_BLUETOOTH, self._address)},
-            name=f"Gicisky {self._identifier}",
-            manufacturer="Gicisky",
-        )
-
-    @cached_property
-    def available(self) -> bool:
-        """Entity always available."""
-        return True
-
-
-class GiciskyLastPreviewTimeSensorEntity(
-    CoordinatorEntity[DataUpdateCoordinator[datetime | None]],
-    SensorEntity,
-):
-    """Representation of a Gicisky BLE last preview time sensor."""
-
-    _attr_device_class = SensorDeviceClass.TIMESTAMP
-    _attr_icon = "mdi:clock-edit-outline"
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        entry: ConfigEntry,
-        coordinator: DataUpdateCoordinator[datetime | None],
-    ) -> None:
-        """Initialize the last preview time sensor."""
-        CoordinatorEntity.__init__(self, coordinator)
-        address = hass.data[DOMAIN][entry.entry_id]["address"]
-        self._address = address
-        self._identifier = address.replace(":", "")[-8:]
-        self._attr_name = f"Gicisky {self._identifier} Last Preview"
-        self._attr_unique_id = f"gicisky_{self._identifier}_last_preview_time"
 
     @property
     def native_value(self) -> datetime | None:


### PR DESCRIPTION
## Summary

- Adds `Preview Content` as a proper `image` entity (alongside the existing camera entity, kept for backwards compatibility)
- `Last Updated Content` image entity unchanged — only updates on real BLE write success
- Drops the timestamp sensors from #66 — `last_updated` on `image` entities provides this natively in HA

## Notes

Camera entity can be removed in a future PR once users have migrated dashboards.

Closes #66