### PR TITLE
Add Display In Sync binary sensor

### DIFF
--- a/custom_components/gicisky/binary_sensor.py
+++ b/custom_components/gicisky/binary_sensor.py
@@ -195,7 +195,12 @@ async def async_setup_entry(
     )
 
     connectivity_coordinator = hass.data[DOMAIN][entry.entry_id]["connectivity_coordinator"]
-    async_add_entities([GiciskyBluetoothConnectivitySensorEntity(hass, entry, connectivity_coordinator)])
+    image_coordinator = hass.data[DOMAIN][entry.entry_id]["image_coordinator"]
+    preview_coordinator = hass.data[DOMAIN][entry.entry_id]["preview_coordinator"]
+    async_add_entities([
+        GiciskyBluetoothConnectivitySensorEntity(hass, entry, connectivity_coordinator),
+        GiciskyDisplayInSyncBinarySensor(hass, entry, image_coordinator, preview_coordinator),
+    ])
 
 class GiciskyBluetoothBinarySensorEntity(
     PassiveBluetoothProcessorEntity[GiciskyPassiveBluetoothDataProcessor[bool | None]],
@@ -265,3 +270,51 @@ class GiciskyBluetoothConnectivitySensorEntity(
         _LOGGER.debug("Updated binary data")
         self._is_on = self.data
         super()._handle_coordinator_update()
+
+
+class GiciskyDisplayInSyncBinarySensor(
+    CoordinatorEntity[DataUpdateCoordinator[bytes | None]],
+    BinarySensorEntity,
+):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        image_coordinator: DataUpdateCoordinator[bytes | None],
+        preview_coordinator: DataUpdateCoordinator[bytes | None],
+    ):
+        CoordinatorEntity.__init__(self, image_coordinator)
+        self._preview_coordinator = preview_coordinator
+        address = hass.data[DOMAIN][entry.entry_id]["address"]
+        self._address = address
+        self._identifier = address.replace(":", "")[-8:]
+        self._attr_name = f"Gicisky {self._identifier} Display In Sync"
+        self._attr_unique_id = f"gicisky_{self._identifier}_display_in_sync"
+
+    @property
+    def is_on(self) -> bool | None:
+        img = self.coordinator.data
+        pre = self._preview_coordinator.data
+        if img is None or pre is None:
+            return None
+        return img == pre
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, self._address)},
+            name=f"Gicisky {self._identifier}",
+            manufacturer="Gicisky",
+        )
+
+    @cached_property
+    def available(self) -> bool:
+        return True
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._preview_coordinator.async_add_listener(
+                self._handle_coordinator_update
+            )
+        )


### PR DESCRIPTION
## Summary
New binary sensor that shows whether the physical display and the preview are in sync — if they are showing the latest content or there is a pending update.

## Why
Makes it easy to trigger automations or show status based on whether the display needs to be refreshed.

Thank you very much again for the review, and apologies if a lot of PRs are coming — I truly believe this is a great integration and want to keep contributing to it.