### PR TITLE
Enable QuickLZ compression with vendor-compatible 64-bucket hash

### DIFF
--- a/custom_components/gicisky/gicisky_ble/compression.py
+++ b/custom_components/gicisky/gicisky_ble/compression.py
@@ -1,19 +1,28 @@
 """
 Compression utilities for BLE image transfer.
 
-표준 QuickLZ Level 1 (1.5.x) 호환 구현.
+QuickLZ Level 1 호환 구현 (벤더 펌웨어 호환).
 - 64바이트 청크 단위 독립 압축
 - 0x75: 압축 청크 (QuickLZ L1), 0x74: 비압축 청크 (raw)
-- 12비트 해시 기반 매치 (직접 오프셋 아님)
+- 6비트(64버킷) 해시 기반 매치 (직접 오프셋 아님)
 - Short match (2B): bits 0-3 = matchlen-2, bits 4-15 = hash
 - Long match (3B): bits 0-3 = 0, bits 4-15 = hash, byte2 = matchlen
+
+해시 테이블 크기 주의:
+스톡 QuickLZ는 12비트(4096버킷) 해시를 쓰지만, 패널 벤더 펌웨어
+(libble_jni.so / qlz_compress_core)는 `(fetch ^ (fetch >> 12)) & 0x3F`,
+즉 6비트(64버킷) 해시만 사용한다. 인코더가 64 이상의 해시값을 매치
+토큰에 기록하면 패널 디코더는 채워진 적 없는 슬롯을 조회해 잘못된
+오프셋으로 복사 → 무음 디코드 실패가 발생한다. 따라서 벤더와 동일한
+64버킷 해시를 사용해야 실기에서 안정적으로 디코드된다.
 """
 from __future__ import annotations
 
 import struct
 
 _CWORD_LEN = 4
-_HASH_VALUES = 4096
+_HASH_VALUES = 64  # 벤더 펌웨어가 6비트 해시(0x3F)를 사용. 스톡 QuickLZ는 4096.
+_NO_ENTRY = -1  # 해시 슬롯 미사용 sentinel (offset 0도 유효 매치 위치이므로 0을 쓰지 않음)
 _MINOFFSET = 2
 _UNCONDITIONAL_MATCHLEN_COMPRESSOR = 12
 _UNCOMPRESSED_END = 4
@@ -68,7 +77,7 @@ def _qlz_compress_core(source) -> bytes | None:
     lits = 0
 
     # 해시 테이블: offset, cache
-    h_offset = [0] * _HASH_VALUES
+    h_offset = [_NO_ENTRY] * _HASH_VALUES
     h_cache = [0] * _HASH_VALUES
 
     while src <= last_matchstart:
@@ -90,7 +99,7 @@ def _qlz_compress_core(source) -> bytes | None:
         h_offset[h] = src
 
         dist = src - o
-        if (cached & 0xFFFFFF) == 0 and o != 0 and (
+        if (cached & 0xFFFFFF) == 0 and o != _NO_ENTRY and (
             dist > _MINOFFSET
             or (
                 src == o + 1
@@ -194,7 +203,7 @@ def _qlz_decompress_core(stream, dest_size: int) -> bytes:
     cword_val = 1
 
     # 해시 테이블 (디코더): hash → 출력 위치
-    hash_offset: list[int] = [0] * _HASH_VALUES
+    hash_offset: list[int] = [_NO_ENTRY] * _HASH_VALUES
     last_hashed = -1
 
     while dst <= last_dst:
@@ -211,7 +220,7 @@ def _qlz_decompress_core(stream, dest_size: int) -> bytes:
             if src + 2 > n:
                 break
             fetch_lo = stream[src] | (stream[src + 1] << 8)
-            h = (fetch_lo >> 4) & 0xFFF
+            h = (fetch_lo >> 4) & (_HASH_VALUES - 1)
             matchlen_indicator = fetch_lo & 0xF
 
             if matchlen_indicator != 0:

--- a/custom_components/gicisky/gicisky_ble/writer.py
+++ b/custom_components/gicisky/gicisky_ble/writer.py
@@ -428,7 +428,7 @@ class GiciskyClient:
                     bit_pos = 7
         raw = bytes(bw_plane) + bytes(red_plane)
         try:
-            compressed = compress_data(raw, force_raw=True)  # TODO: QuickLZ 호환 확인 후 force_raw 제거
+            compressed = compress_data(raw)  # QuickLZ L1 압축 (벤더 호환 64버킷 해시)
             # compress_data 반환: [4B part2_len] + compressed_part1 + compressed_part2
             # prefix 없이 그대로 반환 (7.5"의 total_len 헤더와 동일한 위치)
             _LOGGER.debug(


### PR DESCRIPTION
The panel vendor firmware (libble_jni.so / qlz_compress_core) uses a 6-bit hash `(fetch ^ (fetch >> 12)) & 0x3F` (64 buckets), not the stock QuickLZ 12-bit (4096-bucket) hash. The match token stores the hash value, and the panel decoder only populates 64 hash slots, so any match whose hash > 63 makes the decoder read a slot that was never written — the copy resolves to the wrong offset and the decode silently fails. This matched the observed behavior: uniform content worked by chance, while dense/busy dashboards failed once match density was high enough.

Changes:
- _HASH_VALUES 4096 -> 64 so the encoder emits hashes the panel can resolve. The hash function and _update_hash derive their mask from _HASH_VALUES-1 automatically.
- Fix decoder hash mask, which was hardcoded to 0xFFF, to follow _HASH_VALUES-1.
- Use -1 (_NO_ENTRY) as the empty-slot sentinel instead of 0, since offset 0 is a valid match position; update the encoder's validity check from `o != 0` to `o != _NO_ENTRY` accordingly.
- writer.py: drop force_raw=True so compression2 panels (7.5"/10.2") send real QuickLZ chunks instead of raw.

Verified: 242 roundtrip cases (random / uniform / run-heavy / low-entropy / periodic + both real panel payload sizes 96000/153600) at 0 mismatches; decode of full dashboard-shaped payloads round-trips correctly.