### PR TITLE
fix: clamp battery percentage at 100

### DIFF
--- a/custom_components/gicisky/gicisky_ble/parser.py
+++ b/custom_components/gicisky/gicisky_ble/parser.py
@@ -74,6 +74,8 @@ class GiciskyBluetoothDeviceData(BluetoothData):
         min = device.min_voltage
         max = device.max_voltage
         batt = (volt - min) * 100 / (max - min)
+        if batt > 100:
+            batt = 100
         self.update_predefined_sensor(SensorLibrary.BATTERY__PERCENTAGE, round(batt, 1))
         self.update_predefined_sensor(
             SensorLibrary.VOLTAGE__ELECTRIC_POTENTIAL_VOLT, round(volt, 1)

--- a/custom_components/gicisky/manifest.json
+++ b/custom_components/gicisky/manifest.json
@@ -23,5 +23,5 @@
   "requirements": [
     "imagespec[datamatrix]==0.3.1"
   ],
-  "version": "5.3.0"
+  "version": "5.3.1"
 }


### PR DESCRIPTION
## Summary
- Cap battery percentage at 100 when calculated voltage exceeds `max_voltage`
- Bump integration version to 5.3.1

## Test plan
- [ ] Confirm a device reporting voltage above `max_voltage` shows battery as 100% (not >100)
- [ ] Confirm normal voltage range still maps to expected percentages
- [ ] Confirm voltage sensor still reports the raw voltage correctly


Made with [Cursor](https://cursor.com)