### PR TITLE
Fix battery percentage negative values

### DIFF
--- a/custom_components/gicisky/gicisky_ble/parser.py
+++ b/custom_components/gicisky/gicisky_ble/parser.py
@@ -71,11 +71,11 @@ class GiciskyBluetoothDeviceData(BluetoothData):
         self.set_device_hw_version(f"0x{hardware:04X}")
 
         volt = battery / 10
-        min = device.min_voltage
-        max = device.max_voltage
-        batt = (volt - min) * 100 / (max - min)
-        if batt > 100:
-            batt = 100
+        min_volt = device.min_voltage
+        max_volt = device.max_voltage
+        batt = (volt - min_volt) * 100 / (max_volt - min_volt)
+        batt = min(100, batt)
+        batt = max(0, batt)
         self.update_predefined_sensor(SensorLibrary.BATTERY__PERCENTAGE, round(batt, 1))
         self.update_predefined_sensor(
             SensorLibrary.VOLTAGE__ELECTRIC_POTENTIAL_VOLT, round(volt, 1)


### PR DESCRIPTION
<img width="566" height="478" alt="image" src="https://github.com/user-attachments/assets/2f48d169-5249-4ce2-83a0-e111b810b7f3" />

Fixes an issue where the battery percentage calculation could drop below 0% (e.g., reaching -50% when voltage falls below min_voltage).
This change clamps the calculated percentage so that values below 0% are capped at 0%, preventing negative percentage readings.